### PR TITLE
Fix invalid HTML nesting in menu partial

### DIFF
--- a/jkerschner.com/themes/wholelattesyntax/layouts/partials/menu.html
+++ b/jkerschner.com/themes/wholelattesyntax/layouts/partials/menu.html
@@ -33,16 +33,16 @@ Renders a menu for the given menu ID.
 {{- $name = . }}
 {{- end }}
 {{- end }}
-<h2>
-  <li>
+<li>
+  <h2>
     <a {{- range $k, $v :=$attrs }} {{- with $v }} {{- printf " %s=%q" $k $v | safeHTMLAttr }} {{- end }} {{- end -}}>{{
       $name }}</a>
-    {{- with .Children }}
-    <ul>
-      {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
-    </ul>
-    {{- end }}
-  </li>
-</h2>
+  </h2>
+  {{- with .Children }}
+  <ul>
+    {{- partial "inline/menu/walk.html" (dict "page" $page "menuEntries" .) }}
+  </ul>
+  {{- end }}
+</li>
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- correct HTML structure in theme menu

## Testing
- `hugo --minify` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f69447cec83329269983ac357f217